### PR TITLE
Allow four satellite network

### DIFF
--- a/GameData/ContractPacks/RemoteTech/KerbinRelay.cfg
+++ b/GameData/ContractPacks/RemoteTech/KerbinRelay.cfg
@@ -133,6 +133,56 @@ CONTRACT_TYPE:NEEDS[RemoteTech]
             name = VesselConnectivity
             type = VesselConnectivity
 
+            vesselKey = CommSat II
+        }
+
+        PARAMETER
+        {
+            name = KSCConnectivity
+            type = KSCConnectivity
+        }
+
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+
+            // 600 km - minimum distance to have line of sight for 3 satellites for Kerbin.
+            minPeA = 600000
+
+            // Pretty close to circular
+            maxEccentricity = 0.004
+
+            // Pretty close to equatorial
+            maxInclination = 1
+        }
+
+        PARAMETER
+        {
+            name = HasAntenna
+            type = HasAntenna
+
+            antennaType = Dish
+            activeVessel = true
+
+            // Able to reach just past Minmus
+            minRange = 48000000
+        }
+    }
+    
+    PARAMETER
+    {
+        name = CommSat4
+        type = VesselParameterGroup
+
+        define = CommSat IV
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = VesselConnectivity
+            type = VesselConnectivity
+
             vesselKey = CommSat I
         }
 
@@ -141,7 +191,7 @@ CONTRACT_TYPE:NEEDS[RemoteTech]
             name = VesselConnectivity
             type = VesselConnectivity
 
-            vesselKey = CommSat II
+            vesselKey = CommSat III
         }
 
         PARAMETER


### PR DESCRIPTION
This modified contract is complete-able with either three or four satellites, but encourages using four satellites just like the tutorial. Because Commsat I and Commsat III can be the same probe, it only takes 2 satellites to complete the placement, but it will fail the 2 day test until the network is completed with a 3rd (or 4th) satellite. Should resolve issue #2.
