### PR TITLE
Increase maxCoverage requirement

### DIFF
--- a/GameData/ContractPacks/RemoteTech/PlanetMoonRelay.cfg
+++ b/GameData/ContractPacks/RemoteTech/PlanetMoonRelay.cfg
@@ -103,6 +103,6 @@ CONTRACT_TYPE:NEEDS[RemoteTech]
     {
         type = CelestialBodyCoverage
 
-        maxCoverage = 0.7
+        maxCoverage = 0.9
     }
 }


### PR DESCRIPTION
Planetary networks for Duna & Eve will often easily also provide >70% coverage for Ike or Gilly. Particularly when the moon is not behind the planet from Kerbin, so a relay sat in orbit of Kerbin probably also covers parts of it. Tested at 0.85 and contract still wasn't becoming available; 0.9 needed for Ike contract to appear.